### PR TITLE
feat: 리워드 지급 기능 추가

### DIFF
--- a/src/main/kotlin/com/example/kotlin/config/AppUtil.kt
+++ b/src/main/kotlin/com/example/kotlin/config/AppUtil.kt
@@ -1,6 +1,10 @@
 package com.example.kotlin.config
 
+import com.example.kotlin.reserveException.ErrorCode
+import com.example.kotlin.reserveException.ReserveException
 import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
 
 fun createCookie(key: String, value: String): Cookie {
 
@@ -10,5 +14,19 @@ fun createCookie(key: String, value: String): Cookie {
         path = "/"
     }
 
+}
+
+fun parsingToken(request: HttpServletRequest): String {
+
+    val authorization = request.getHeader("Authorization")
+        ?: throw ReserveException(HttpStatus.UNAUTHORIZED, ErrorCode.NOT_EXIST_AUTHORIZATION_IN_HEADER)
+
+    if (!authorization.startsWith("Bearer ")) {
+        throw ReserveException(HttpStatus.UNAUTHORIZED, ErrorCode.NOT_EXIST_AUTHORIZATION_IN_HEADER)
+    }
+
+    val token = authorization.substring(7)
+
+    return token
 }
 

--- a/src/main/kotlin/com/example/kotlin/member/Member.kt
+++ b/src/main/kotlin/com/example/kotlin/member/Member.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import java.time.LocalDate
 
 @Entity
 class Member(
@@ -22,5 +23,9 @@ class Member(
 
     val email: String,
 
-    val credit: Long = 30000
+    var credit: Long = 30000,
+
+    var reward: Long,
+
+    var last_reward_date: LocalDate? = null
 ): BaseTime()

--- a/src/main/kotlin/com/example/kotlin/member/MemberController.kt
+++ b/src/main/kotlin/com/example/kotlin/member/MemberController.kt
@@ -1,13 +1,15 @@
 package com.example.kotlin.member
 
+import com.example.kotlin.config.parsingToken
 import jakarta.servlet.http.HttpServletRequest
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @RequestMapping("/member")
 @RestController
@@ -19,14 +21,7 @@ class MemberController(
     @GetMapping("/info")
     fun memberInfo(request: HttpServletRequest): ResponseEntity<MemberResponse> {
 
-        val authorization = request.getHeader("Authorization")
-            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-
-        if (!authorization.startsWith("Bearer ")) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-        }
-
-        val token = authorization.substring(7)
+        val token = parsingToken(request)
 
         return memberService.memberInfo(token)
     }
@@ -35,4 +30,15 @@ class MemberController(
     fun saveMember(@RequestBody memberRequest: MemberRequest) {
         memberService.saveMember(memberRequest)
     }
+
+    @PostMapping("/reward/{today}")
+    fun setRewardDate(request: HttpServletRequest, @PathVariable("today") today: LocalDate): ResponseEntity<String> {
+
+        val token: String = parsingToken(request)
+
+        println("받은 날짜: $today")
+
+        return memberService.setRewardDate(token, today)
+    }
 }
+

--- a/src/main/kotlin/com/example/kotlin/member/MemberRequest.kt
+++ b/src/main/kotlin/com/example/kotlin/member/MemberRequest.kt
@@ -9,7 +9,9 @@ data class MemberRequest (
 
     val role: Role = Role.MEMBER,
 
-    val email: String
+    val email: String,
+
+    var reward: Long
 ) {
     fun toEntity(password: String): Member {
         return Member(
@@ -17,7 +19,8 @@ data class MemberRequest (
             password = password,
             name = this.name,
             role = this.role,
-            email = this.email
+            email = this.email,
+            reward = 0
         )
     }
 }

--- a/src/main/kotlin/com/example/kotlin/member/MemberResponse.kt
+++ b/src/main/kotlin/com/example/kotlin/member/MemberResponse.kt
@@ -1,5 +1,7 @@
 package com.example.kotlin.member
 
+import java.time.LocalDate
+
 data class MemberResponse(
 
     val id: Long? = null,
@@ -10,5 +12,7 @@ data class MemberResponse(
 
     val role: Role,
 
-    val email: String
+    val email: String,
+
+    var last_reward_date: LocalDate?
 )

--- a/src/main/kotlin/com/example/kotlin/place/Place.kt
+++ b/src/main/kotlin/com/example/kotlin/place/Place.kt
@@ -17,5 +17,4 @@ class Place(
     val name: String,
 
     val location: String
-
 )

--- a/src/main/kotlin/com/example/kotlin/reserveException/ErrorCode.kt
+++ b/src/main/kotlin/com/example/kotlin/reserveException/ErrorCode.kt
@@ -29,5 +29,9 @@ enum class ErrorCode (
 
     FAIL_TO_RETURN_RESERVED_SEAT_LIST("FAIL_TO_RETURN_RESERVED_SEAT_LIST", "예약 좌석 리스트 반환 실패"),
 
-    NOT_ENOUGH_CREDIT("NOT_ENOUGH_CREDIT", "보유 금액이 부족합니다.")
+    NOT_ENOUGH_CREDIT("NOT_ENOUGH_CREDIT", "보유 금액이 부족합니다."),
+
+    NOT_EXIST_AUTHORIZATION_IN_HEADER("NOT_EXIST_AUTHORIZATION_IN_HEADER", "Header에 Authorization이 존재하지 않습니다."),
+
+    REWARD_ALREADY_CLAIMED("REWARD_ALREADY_CLAIMED", "오늘 이미 리워드를 지급받았습니다.")
 }


### PR DESCRIPTION
현재 리워드 기능은 사용자의 중복 클릭에 의해 동시에 여러 요청이 처리되는 문제가 발생할 수 있기에, 추후 락을 적용하여 동시성 문제를 방지하고, 트랜잭션을 내부 비즈니스 로직과 외부 API 호출로 분리하여 처리 속도와 안정성을 높일 예정이며, 또한, 지급 이력을 기반으로 동일 요청에 대해 항상 같은 응답을 반환하는 멱등성 구조를 도입해, 중복 요청 시에도 일관된 결과를 보장하도록 개선 예정입니다.